### PR TITLE
Switch to using feature specs, add helper spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,20 +20,20 @@ Should be run from the archivesspace project root directory.
 
 To run headless (default):
 ```
-.build/run frontend:selenium -Dspec="../../plugins/caas_aspace_sova_button/frontend/spec/toolbar_spec.rb"
+./build/run frontend:test -Dpattern="../../plugins/caas_aspace_sova_button/frontend/spec/*"
 ```
 
 To run headless with Chrome:
 ```
-SELENIUM_CHROME=true .build/run frontend:selenium -Dspec="../../plugins/caas_aspace_sova_button/frontend/spec/toolbar_spec.rb"
+SELENIUM_CHROME=true ./build/run frontend:test -Dpattern="../../plugins/caas_aspace_sova_button/frontend/spec/*"
 ```
 
 To run heady with Chrome (chromedriver required):
 ```
-SELENIUM_CHROME=true CHROME_OPTS= .build/run frontend:selenium -Dspec="../../plugins/caas_aspace_sova_button/frontend/spec/toolbar_spec.rb"
+SELENIUM_CHROME=true CHROME_OPTS= ./build/run frontend:test -Dpattern="../../plugins/caas_aspace_sova_button/frontend/spec/*"
 ```
 
 To run heady with Firefox (geckodriver required):
 ```
-FIREFOX_OPTS= .build/run frontend:selenium -Dspec="../../plugins/caas_aspace_sova_button/frontend/spec/toolbar_spec.rb"
+FIREFOX_OPTS= ./build/run frontend:test -Dpattern="../../plugins/caas_aspace_sova_button/frontend/spec/*"
 ```

--- a/frontend/spec/toolbar_helper_spec.rb
+++ b/frontend/spec/toolbar_helper_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "#{ASUtils.find_base_directory}/frontend/spec/spec_helper"
+require "#{ASUtils.find_base_directory}/frontend/spec/rails_helper"
+
+describe ToolbarHelper do
+  describe '#sova_link_from_record' do
+    context 'when a resource' do
+      let(:record_id) {'EAD.123'}
+      let(:record_type) { 'resource' }
+
+      it "returns '/record/{downcased-eadid}'" do
+        expect(ToolbarHelper::sova_link_from_record(record_id, record_type)).to eq('/record/ead.123')
+      end
+    end
+
+    context 'when an archival object' do
+      let(:record_id) {'EAD.123_ref1'}
+      let(:record_type) { 'archival_object' }
+
+      it "returns '/record/{downcased-eadid}/{refid}'" do
+        expect(ToolbarHelper::sova_link_from_record(record_id, record_type)).to eq('/record/ead.123/ref1')
+      end
+    end
+  end
+end

--- a/frontend/spec/toolbar_spec.rb
+++ b/frontend/spec/toolbar_spec.rb
@@ -1,90 +1,100 @@
 # frozen_string_literal: true
 
-require_relative '../../../../frontend/spec/selenium/spec_helper'
+require "#{ASUtils.find_base_directory}/frontend/spec/spec_helper"
+require "#{ASUtils.find_base_directory}/frontend/spec/rails_helper"
 
-describe 'View in SOVA toolbar button' do
-  before(:all) do
-    @repo = create(:repo, repo_code: "caas_aspace_sova_button_test_#{Time.now.to_i}")
-    set_repo @repo
+def add_enum
+  visit "resources/#{@published_resource.id}/edit"
+  already_set = find('#resource_finding_aid_status_').value == 'publish'
+  unless already_set
+    click_on 'System'
+    click_on 'Manage Controlled Value Lists'
 
-    @user = create_user(@repo => ['repository-managers'])
-    @driver = Driver.get.login_to_repo(@user, @repo)
+    select 'Resource Finding Aid Status (resource_finding_aid_status)', from: 'List Name'
 
-    # We've got to add our custome finding aid status enum
-    @driver.find_element(:link, 'System').click
-    @driver.wait_for_dropdown
-    @driver.click_and_wait_until_gone(:link, 'Manage Controlled Value Lists')
-    sleep(0.5)
-    enum_select = @driver.find_element(id: 'enum_selector')
-    enum_select.select_option_with_text('Resource Finding Aid Status (resource_finding_aid_status)')
-    @driver.find_element(:link, 'Create Value').click
-    @driver.clear_and_send_keys([:id, 'enumeration_value_'], 'publish')
-    @driver.click_and_wait_until_gone(:css, '.modal-footer .btn-primary')
+    element = find('a', text: 'Create Value')
+    element.click
+
+    within '#form_enumeration' do
+      fill_in 'enumeration_value_', with: 'publish'
+      click_on 'Create Value'
+    end
+
+    element = find('.alert.alert-success.with-hide-alert')
+    expect(element.text).to eq 'Value Created'
+    expect(page).to have_css 'tr', text: 'publish'
+
     run_index_round
 
-    @resource = create(:resource,
-                       ead_id: 'USA.123')
-    # @archival_object = create(:archival_object,
-    #                           resource: { 'ref' => @resource.uri })
+    visit "resources/#{@published_resource.id}/edit"
+    select 'publish', from: 'Finding Aid Status'
+    within '#archivesSpaceSidebar' do
+      click_on 'Save Resource'
+    end
+
+    wait_for_ajax
+  end
+end
+
+describe 'View in SOVA toolbar button', js: true do
+  before(:all) do
+    @repository = create(:repo, repo_code: "caas_aspace_sova_button_test_#{Time.now.to_i}")
+
+    set_repo @repository
+
+    @resource = create(:resource, title: "Unpublished Resource", ead_id: 'USA.123')
+    @published_resource = create(:resource, title: "Published Resource", ead_id: 'USA.456')
+    @unpublished_ao = create(:archival_object, title: "Archival Object Unpublished Resource", resource: { ref: @resource.uri })
+    @published_ao = create(:archival_object, title: "Archival Object Published Resource", resource: { ref: @published_resource.uri })
+
+    run_index_round
   end
 
   before(:each) do
-    @driver.go_home
-  end
-
-  after(:all) do
-    @driver ? @driver.quit : next
+    login_admin
+    select_repository(@repository)
   end
 
   context 'when finding aid status is not publish' do
     it 'does not show the button on the resource' do
-      @driver.get_edit_page(@resource)
+      visit "resources/#{@resource.id}"
+      wait_for_ajax
 
-      expect(@driver.find_elements(:link, 'View in SOVA').length).to eq(0)
+      expect(page).not_to have_text 'View in SOVA'
     end
 
     it 'does not show the button on a child archival object' do
-      @driver.get_edit_page(@resource)
+      visit "resources/#{@resource.id}/edit#tree::archival_object_#{@unpublished_ao.id}"
 
-      # Create archival object
-      @driver.find_element(:link, 'Add Child').click
-      @driver.clear_and_send_keys([:id, 'archival_object_title_'], 'New archival object')
-      @driver.find_element(:id, 'archival_object_level_').select_option('item')
-      @driver.click_and_wait_until_gone(css: "form#archival_object_form button[type='submit']")
+      wait_for_ajax
 
-      expect(@driver.find_elements(:link, 'View in SOVA').length).to eq(0)
+      expect(page).not_to have_text 'View in SOVA'
     end
   end
 
   context 'when finding aid status is publish' do
-    before do
-      @driver.get_edit_page(@resource)
-
-      finding_aid_data = @driver.find_element(xpath: '//select[contains(@id, "resource_finding_aid_status_")]')
-      finding_aid_data.select_option_with_text('publish')
-      @driver.click_and_wait_until_gone(css: "form#resource_form button[type='submit']")
+    before(:each) do
+      add_enum
     end
 
     it 'shows the button with correct sova link on the resource' do
-      @driver.get_edit_page(@resource)
-      @driver.wait_for_ajax
+      visit "resources/#{@published_resource.id}/edit"
 
-      expect(@driver.find_elements(:link, 'View in SOVA').length).to eq(1)
-      expect(@driver.find_element(:link, 'View in SOVA').attribute('href')).to match('https://sova.si.edu/record/usa.123')
+      expect(page).to have_text 'View in SOVA'
+
+      button = find(:xpath, '//a[text()="View in SOVA"]')
+      expect(button[:href]).to match('https://sova.si.edu/record/usa.456')
     end
 
     it 'shows the button with correct sova link on a child archival object' do
-      @driver.get_edit_page(@resource)
-      @driver.find_element(:link, 'New archival object').click
+      visit "resources/#{@published_resource.id}/edit#tree::archival_object_#{@published_ao.id}"
 
-      expect(@driver.find_elements(:link, 'View in SOVA').length).to eq(1)
+      wait_for_ajax
 
-      # If using the ref_id plugin we can predict the full url, if not, we can't
-      if AppConfig[:plugins].include?('caas_aspace_refid')
-        expect(@driver.find_element(:link, 'View in SOVA').attribute('href')).to match('https://sova.si.edu/record/usa.123/ref1')
-      else
-        expect(@driver.find_element(:link, 'View in SOVA').attribute('href')).to start_with('https://sova.si.edu/record/')
-      end
+      expect(page).to have_text 'View in SOVA'
+
+      button = find(:xpath, '//a[text()="View in SOVA"]')
+      expect(button[:href]).to start_with('https://sova.si.edu/record/')
     end
   end
 end


### PR DESCRIPTION
Selenium specs have been [removed upstream](https://github.com/archivesspace/archivesspace/pull/3189) (hooray!), so we shouldn't use them either.  Moving to much slimmer feature specs.  Also, separating out unnecessary complexity in the selenium-now-feature specs that relied on the presence of `caas_aspace_refid` plugin, and just checking the helper logic outright in a helper spec.