### PR TITLE
Derive sova environment from aspace url

### DIFF
--- a/frontend/helpers/toolbar_helper.rb
+++ b/frontend/helpers/toolbar_helper.rb
@@ -1,5 +1,6 @@
 module ToolbarHelper
-  SOVA_URN = "sova.si.edu"
+  SOVA_PROD_DOMAIN = 'sova.si.edu'
+  SOVA_TEST_DOMAIN = 'sova-test.si.edu'
 
   def self.sova_link_from_record(record_id, record_type)
     path = record_id.downcase
@@ -9,5 +10,13 @@ module ToolbarHelper
 
     File.join('/record/',
               path)
+  end
+
+  def self.sova_base_domain(host)
+    if host.exclude?('test')
+      SOVA_PROD_DOMAIN
+    else
+      SOVA_TEST_DOMAIN
+    end
   end
 end

--- a/frontend/spec/toolbar_helper_spec.rb
+++ b/frontend/spec/toolbar_helper_spec.rb
@@ -23,4 +23,22 @@ describe ToolbarHelper do
       end
     end
   end
+
+  describe '#sova_base_domain' do
+    context 'when aspace url looks like SI production' do
+      let(:aspace_host) { 'aspace.myorg.edu' }
+
+      it "returns '/record/{downcased-eadid}'" do
+        expect(ToolbarHelper::sova_base_domain(aspace_host)).to eq('sova.si.edu')
+      end
+    end
+
+    context 'when aspace url looks like SI test' do
+      let(:aspace_host) { 'aspace-test.myorg.edu' }
+
+      it "returns '/record/{downcased-eadid}/{refid}'" do
+        expect(ToolbarHelper::sova_base_domain(aspace_host)).to eq('sova-test.si.edu')
+      end
+    end
+  end
 end

--- a/frontend/views/shared/_component_toolbar.html.erb
+++ b/frontend/views/shared/_component_toolbar.html.erb
@@ -62,7 +62,8 @@
           <%# View in SOVA plugin start %>
           <% if ['archival_object'].include?(record.jsonmodel_type) && JSONModel(:resource).find(parent_link[:id]).finding_aid_status == 'publish' %>
             <%= link_to t('view_in_sova'),
-                        URI::HTTPS.build(host: ToolbarHelper::SOVA_URN, path: ToolbarHelper::sova_link_from_record(record.ref_id, 'archival_object')).to_s,
+                        URI::HTTPS.build(host: ToolbarHelper::sova_base_domain(request.host),
+                                        path: ToolbarHelper::sova_link_from_record(record.ref_id, 'archival_object')).to_s,
                         { :class => "btn btn-sm btn-default", :target => "_blank" } %>
           <% end %>
           <%# View in SOVA plugin end %>

--- a/frontend/views/shared/_resource_toolbar.html.erb
+++ b/frontend/views/shared/_resource_toolbar.html.erb
@@ -90,7 +90,8 @@
       <%# View in SOVA plugin start %>
       <% if record.finding_aid_status == 'publish' %>
         <%= link_to t('view_in_sova'),
-                    URI::HTTPS.build(host: ToolbarHelper::SOVA_URN, path: ToolbarHelper::sova_link_from_record(record.ead_id, 'resource')).to_s,
+                    URI::HTTPS.build(host: ToolbarHelper::sova_base_domain(request.host),
+                                     path: ToolbarHelper::sova_link_from_record(record.ead_id, 'resource')).to_s,
                     { :class => "btn btn-sm btn-default", :target => "_blank" } %>
       <% end %>
       <%# View in SOVA plugin end %>


### PR DESCRIPTION
If the current ArchivesSpace page's hostname does not include `test`, direct the "View in SOVA" button to SOVA production.  Otherwise, point to SOVA test.

Closes #8 