### PR TITLE
Set SOVA base url in config.rb

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,16 @@ For the above to work, the `caas_aspace_sova_button` must be loaded last, such a
 AppConfig[:plugins] = ['local', 'lcnaf', 'snac_aspace_plugin', 'some-other-plugin', 'caas_aspace_sova_button']
 ```
 
+## Configuring SOVA environment
+
+To (optionally) configure the base SOVA URL (e.g. test or prod) add the following to your ArchivesSpace `config.yml`:
+
+```
+ AppConfig[:soval_url] = 'https://sova-test.si.edu/'
+```
+
+If no configuration setting is supplied, the system will fallback to the production SOVA URL defined in `caas_aspace_sova_button/frontend/plugin_init.rb`.
+
 ## Tests
 
 Should be run from the archivesspace project root directory.

--- a/frontend/helpers/toolbar_helper.rb
+++ b/frontend/helpers/toolbar_helper.rb
@@ -1,7 +1,4 @@
 module ToolbarHelper
-  SOVA_PROD_DOMAIN = 'sova.si.edu'
-  SOVA_TEST_DOMAIN = 'sova-test.si.edu'
-
   def self.sova_link_from_record(record_id, record_type)
     path = record_id.downcase
     if record_type == 'archival_object'
@@ -10,13 +7,5 @@ module ToolbarHelper
 
     File.join('/record/',
               path)
-  end
-
-  def self.sova_base_domain(host)
-    if host.exclude?('test')
-      SOVA_PROD_DOMAIN
-    else
-      SOVA_TEST_DOMAIN
-    end
   end
 end

--- a/frontend/plugin_init.rb
+++ b/frontend/plugin_init.rb
@@ -1,3 +1,10 @@
 module ApplicationHelper
   require_relative 'helpers/toolbar_helper.rb'
 end
+
+# If the sova_url has not been set in config.rb, fallback to the production URL.
+Rails.application.config.after_initialize do
+  if !AppConfig.has_key?(:sova_url)
+    AppConfig[:sova_url] = 'https://sova.si.edu'
+  end
+end

--- a/frontend/spec/toolbar_helper_spec.rb
+++ b/frontend/spec/toolbar_helper_spec.rb
@@ -23,22 +23,4 @@ describe ToolbarHelper do
       end
     end
   end
-
-  describe '#sova_base_domain' do
-    context 'when aspace url looks like SI production' do
-      let(:aspace_host) { 'aspace.myorg.edu' }
-
-      it "returns '/record/{downcased-eadid}'" do
-        expect(ToolbarHelper::sova_base_domain(aspace_host)).to eq('sova.si.edu')
-      end
-    end
-
-    context 'when aspace url looks like SI test' do
-      let(:aspace_host) { 'aspace-test.myorg.edu' }
-
-      it "returns '/record/{downcased-eadid}/{refid}'" do
-        expect(ToolbarHelper::sova_base_domain(aspace_host)).to eq('sova-test.si.edu')
-      end
-    end
-  end
 end

--- a/frontend/views/shared/_component_toolbar.html.erb
+++ b/frontend/views/shared/_component_toolbar.html.erb
@@ -62,8 +62,8 @@
           <%# View in SOVA plugin start %>
           <% if ['archival_object'].include?(record.jsonmodel_type) && JSONModel(:resource).find(parent_link[:id]).finding_aid_status == 'publish' %>
             <%= link_to t('view_in_sova'),
-                        URI::HTTPS.build(host: ToolbarHelper::sova_base_domain(request.host),
-                                        path: ToolbarHelper::sova_link_from_record(record.ref_id, 'archival_object')).to_s,
+                        URI::HTTPS.build(host: URI(AppConfig[:sova_url]).hostname,
+                                         path: ToolbarHelper::sova_link_from_record(record.ref_id, 'archival_object')).to_s,
                         { :class => "btn btn-sm btn-default", :target => "_blank" } %>
           <% end %>
           <%# View in SOVA plugin end %>

--- a/frontend/views/shared/_resource_toolbar.html.erb
+++ b/frontend/views/shared/_resource_toolbar.html.erb
@@ -90,7 +90,7 @@
       <%# View in SOVA plugin start %>
       <% if record.finding_aid_status == 'publish' %>
         <%= link_to t('view_in_sova'),
-                    URI::HTTPS.build(host: ToolbarHelper::sova_base_domain(request.host),
+                    URI::HTTPS.build(host: URI(AppConfig[:sova_url]).hostname,
                                      path: ToolbarHelper::sova_link_from_record(record.ead_id, 'resource')).to_s,
                     { :class => "btn btn-sm btn-default", :target => "_blank" } %>
       <% end %>


### PR DESCRIPTION
Allows for the SOVA base url to be set in the main `config.rb`.  If not provided, falls back to the production SOVA url.