### PR TITLE
Ensure button is only shown on resource

### DIFF
--- a/frontend/views/shared/_resource_toolbar.html.erb
+++ b/frontend/views/shared/_resource_toolbar.html.erb
@@ -88,7 +88,7 @@
       <% end %>
 
       <%# View in SOVA plugin start %>
-      <% if record.finding_aid_status == 'publish' %>
+      <% if ['resource'].include?(record.jsonmodel_type) && record.finding_aid_status == 'publish' %>
         <%= link_to t('view_in_sova'),
                     URI::HTTPS.build(host: ToolbarHelper::sova_base_domain(request.host),
                                      path: ToolbarHelper::sova_link_from_record(record.ead_id, 'resource')).to_s,


### PR DESCRIPTION
Bugfix to ensure the "View in SOVA" resource toolbar button is only shown on a resource record, NOT a digital object record which apparently also uses the `_resource_toolbar.html.erb` toolbar partial.