### PR TITLE
Do not show button on unpublished ao

### DIFF
--- a/frontend/views/shared/_component_toolbar.html.erb
+++ b/frontend/views/shared/_component_toolbar.html.erb
@@ -60,7 +60,7 @@
           <% end %>
 
           <%# View in SOVA plugin start %>
-          <% if ['archival_object'].include?(record.jsonmodel_type) && JSONModel(:resource).find(parent_link[:id]).finding_aid_status == 'publish' %>
+          <% if ['archival_object'].include?(record.jsonmodel_type) && JSONModel(:resource).find(parent_link[:id]).finding_aid_status == 'publish' && record.publish == true %>
             <%= link_to t('view_in_sova'),
                         URI::HTTPS.build(host: URI(AppConfig[:sova_url]).hostname,
                                          path: ToolbarHelper::sova_link_from_record(record.ref_id, 'archival_object')).to_s,


### PR DESCRIPTION
## Description
Only shows "View in SOVA" button in archival object toolbar if archival object is published.

## Related GitHub Issue
Closes #14 

## Testing
Additional test added and passing.

## Screenshot(s):
<!--- Optional screenshots of changes if relevant and helpful to reviewers -->
Parent has the button:
<img width="1171" alt="Screenshot 2024-09-19 at 9 58 29 AM" src="https://github.com/user-attachments/assets/832beb63-8c28-4e41-b853-73daf533c81e">

But unpublished AO does not:
<img width="1184" alt="Screenshot 2024-09-19 at 9 58 44 AM" src="https://github.com/user-attachments/assets/115e47e3-2789-4899-be02-7e999c0b38cf">

## Checklist

- [x] ✔️ Have you assigned at least one reviewer?
- [x] 🔗 Have you referenced any issues this PR will close?
- [x] ⬇️ Have you merged the latest upstream changes into your branch? 
- [x] 🧪 Have you added tests to cover these changes?  If not, why:
- [x] 🤖 Have automated checks (if any) passed?  If not, please explain for the reviewer:
- [x] 📘 Have you updated/added any relevant readmes/comments in the codebase?
- [ ] 📚 Have you updated/added any external documentation (e.g. Confluence)?
N/A