### PR TITLE
Run SOVA button plugin tests automatically in CI #5

### DIFF
--- a/.github/workflows/frontend_plugin_test.yml
+++ b/.github/workflows/frontend_plugin_test.yml
@@ -1,0 +1,63 @@
+name: Frontend Plugin Testing
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+
+jobs:
+  frontend_plugins:
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.head_commit.message, '[ci skip]') }}
+    env:
+      DB_PORT: '3307'
+      SOLR_ENABLED: true
+    continue-on-error: true
+    strategy:
+      matrix:
+        archivesspace_version: [v3.3.1, v4.0.0]
+
+    services:
+      db:
+        image: mysql:8
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: archivesspace
+          MYSQL_USER: as
+          MYSQL_PASSWORD: as123
+        ports:
+          - 3307:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+      solr:
+        image: solr:9.4.1
+        env:
+          SOLR_MODULES: analysis-extras
+        ports:
+          - 8984:8983
+
+    steps:
+    - name: Setup ArchivesSpace ${{ matrix.archivesspace_version }}
+      uses: Smithsonian/caas-aspace-services/.github/actions/setup_archivesspace@9_solr_service
+      with:
+        archivesspace-version: ${{ matrix.archivesspace_version }}
+        db-port: ${{ env.DB_PORT }}
+        plugin: ${{ github.event.repository.name }}
+        solr-enabled: ${{ env.SOLR_ENABLED }}
+
+    - name: Bootstrap ArchivesSpace
+      uses: Smithsonian/caas-aspace-services/.github/actions/bootstrap@main
+      with:
+        backend: 'true'
+        frontend: 'true'
+        indexer: 'true'
+      
+    - name: Setup firefox
+      id: setup-firefox
+      uses: browser-actions/setup-firefox@v1
+      with:
+        firefox-version: 'latest'
+
+    - name: Run Frontend plugin tests
+      run: |
+        ./build/run frontend:test -Dpattern="../../plugins/${{ github.event.repository.name }}/frontend/spec/*"

--- a/.github/workflows/frontend_plugin_test.yml
+++ b/.github/workflows/frontend_plugin_test.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
     - name: Setup ArchivesSpace ${{ matrix.archivesspace_version }}
-      uses: Smithsonian/caas-aspace-services/.github/actions/setup_archivesspace@9_solr_service
+      uses: Smithsonian/caas-aspace-services/.github/actions/setup_archivesspace@main
       with:
         archivesspace-version: ${{ matrix.archivesspace_version }}
         db-port: ${{ env.DB_PORT }}

--- a/frontend/spec/toolbar_spec.rb
+++ b/frontend/spec/toolbar_spec.rb
@@ -60,12 +60,14 @@ describe 'View in SOVA toolbar button', js: true do
   end
 
   before(:each) do
+    visit '/logout'
     login_admin
     select_repository(@repository)
   end
 
   context 'when finding aid status is not publish' do
     it 'does not show the button on the resource' do
+      visit '/'
       visit "resources/#{@unpublished_resource.id}"
       wait_for_ajax
 
@@ -73,6 +75,7 @@ describe 'View in SOVA toolbar button', js: true do
     end
 
     it 'does not show the button on a child archival object' do
+      visit '/'
       visit "resources/#{@unpublished_resource.id}/edit#tree::archival_object_#{@unpublished_resource_ao.id}"
 
       wait_for_ajax
@@ -87,6 +90,7 @@ describe 'View in SOVA toolbar button', js: true do
     end
 
     it 'shows the button with correct sova link on the resource' do
+      visit '/'
       visit "resources/#{@published_resource.id}/edit"
 
       expect(page).to have_text 'View in SOVA'
@@ -96,6 +100,7 @@ describe 'View in SOVA toolbar button', js: true do
     end
 
     it 'shows the button with correct sova link on a published child archival object' do
+      visit '/'
       visit "resources/#{@published_resource.id}/edit#tree::archival_object_#{@published_ao.id}"
 
       wait_for_ajax
@@ -107,6 +112,7 @@ describe 'View in SOVA toolbar button', js: true do
     end
 
     it 'does not show the button on an unpublished child archival object' do
+      visit '/'
       visit "resources/#{@published_resource.id}/edit#tree::archival_object_#{@unpublished_ao.id}"
 
       wait_for_ajax


### PR DESCRIPTION
## Description
We've had tests for a while, but they've not been running in CI.  This fixes that.  It also makes use of the updated shared composite action added via https://github.com/Smithsonian/caas-aspace-services/issues/9

NOTE: I've set tests to run forward looking against our future target version of ASpace v4.0.0, but these will currently fail.  There's some upstream CSS changes we'll have to look into to get these tests to pass under 4.x.  These failures are expected, and shouldn't block merging.

## Related GitHub Issue
Closes #5 

## Testing
Current tests tweaked to remove some flakiness, and, most importantly, now they'll run in CI.

## Checklist

- [ ] ✔️ Have you assigned at least one reviewer?
NA - There are no actual code changes here, so skipping a formal review.
- [x] 🔗 Have you referenced any issues this PR will close?
- [x] ⬇️ Have you merged the latest upstream changes into your branch? 
- [x] 🧪 Have you added tests to cover these changes?  If not, why:
- [ ] 🤖 Have automated checks (if any) passed?  If not, please explain for the reviewer:
See note above about failure of optional forward-looking v4.0.0 tests
- [x] 📘 Have you updated/added any relevant readmes/comments in the codebase?
- [x] 📚 Have you updated/added any external documentation (e.g. Confluence)?
