### PR TITLE
[FEATURE] Address changes needed for 4.x compatibility #19

### DIFF
--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -15,3 +15,5 @@ on:
 jobs:
   diff:
     uses: Smithsonian/caas-aspace-services/.github/workflows/diff.yml@main
+    with:
+      prod_archivesspace_version: v4.1.0

--- a/.github/workflows/frontend_plugin_test.yml
+++ b/.github/workflows/frontend_plugin_test.yml
@@ -16,7 +16,7 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        archivesspace_version: [v3.3.1, v4.0.0]
+        archivesspace_version: [v4.0.0, v4.1.0]
 
     services:
       db:
@@ -60,4 +60,10 @@ jobs:
 
     - name: Run Frontend plugin tests
       run: |
-        ./build/run frontend:test -Dpattern="../../plugins/${{ github.event.repository.name }}/frontend/spec/*"
+        ./build/run frontend:test -Dpattern="../../plugins/${{ github.event.repository.name }}/frontend/spec/features/*"
+
+    - uses: actions/upload-artifact@v4
+      if: failure()
+      with:
+        name: failed_frontend_spec_${{ github.event.repository.name }}_${{ matrix.archivesspace_version }}
+        path: 'ci_logs'

--- a/README.md
+++ b/README.md
@@ -30,20 +30,20 @@ Should be run from the archivesspace project root directory.
 
 To run headless (default):
 ```
-./build/run frontend:test -Dpattern="../../plugins/caas_aspace_sova_button/frontend/spec/*"
+./build/run frontend:test -Dpattern="../../plugins/caas_aspace_sova_button/frontend/spec/features/*"
 ```
 
 To run headless with Chrome:
 ```
-SELENIUM_CHROME=true ./build/run frontend:test -Dpattern="../../plugins/caas_aspace_sova_button/frontend/spec/*"
+SELENIUM_CHROME=true ./build/run frontend:test -Dpattern="../../plugins/caas_aspace_sova_button/frontend/spec/features/*"
 ```
 
 To run heady with Chrome (chromedriver required):
 ```
-SELENIUM_CHROME=true CHROME_OPTS= ./build/run frontend:test -Dpattern="../../plugins/caas_aspace_sova_button/frontend/spec/*"
+SELENIUM_CHROME=true CHROME_OPTS= ./build/run frontend:test -Dpattern="../../plugins/caas_aspace_sova_button/frontend/spec/features/*"
 ```
 
 To run heady with Firefox (geckodriver required):
 ```
-FIREFOX_OPTS= ./build/run frontend:test -Dpattern="../../plugins/caas_aspace_sova_button/frontend/spec/*"
+FIREFOX_OPTS= ./build/run frontend:test -Dpattern="../../plugins/caas_aspace_sova_button/frontend/spec/features/*"
 ```

--- a/frontend/spec/features/toolbar_helper_spec.rb
+++ b/frontend/spec/features/toolbar_helper_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require "#{ASUtils.find_base_directory}/frontend/spec/spec_helper"
-require "#{ASUtils.find_base_directory}/frontend/spec/rails_helper"
+require 'spec_helper.rb'
+require 'rails_helper.rb'
 
 describe ToolbarHelper do
   describe '#sova_link_from_record' do

--- a/frontend/spec/features/toolbar_spec.rb
+++ b/frontend/spec/features/toolbar_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require "#{ASUtils.find_base_directory}/frontend/spec/spec_helper"
-require "#{ASUtils.find_base_directory}/frontend/spec/rails_helper"
+require 'spec_helper.rb'
+require 'rails_helper.rb'
 
 def add_enum
   visit "resources/#{@published_resource.id}/edit"
@@ -31,17 +31,11 @@ def add_enum
     within '#archivesSpaceSidebar' do
       click_on 'Save Resource'
     end
-
-    wait_for_ajax
   end
 end
 
 describe 'View in SOVA toolbar button', js: true do
   before(:all) do
-    @repository = create(:repo, repo_code: "caas_aspace_sova_button_test_#{Time.now.to_i}")
-
-    set_repo @repository
-
     @unpublished_resource = create(:resource, title: "Unpublished Resource", ead_id: 'USA.123')
     @published_resource = create(:resource, title: "Published Resource", ead_id: 'USA.456')
     @unpublished_resource_ao = create(:archival_object,
@@ -60,14 +54,11 @@ describe 'View in SOVA toolbar button', js: true do
   end
 
   before(:each) do
-    visit '/logout'
     login_admin
-    select_repository(@repository)
   end
 
   context 'when finding aid status is not publish' do
     it 'does not show the button on the resource' do
-      visit '/'
       visit "resources/#{@unpublished_resource.id}"
       wait_for_ajax
 
@@ -75,7 +66,6 @@ describe 'View in SOVA toolbar button', js: true do
     end
 
     it 'does not show the button on a child archival object' do
-      visit '/'
       visit "resources/#{@unpublished_resource.id}/edit#tree::archival_object_#{@unpublished_resource_ao.id}"
 
       wait_for_ajax
@@ -90,7 +80,6 @@ describe 'View in SOVA toolbar button', js: true do
     end
 
     it 'shows the button with correct sova link on the resource' do
-      visit '/'
       visit "resources/#{@published_resource.id}/edit"
 
       expect(page).to have_text 'View in SOVA'
@@ -100,7 +89,6 @@ describe 'View in SOVA toolbar button', js: true do
     end
 
     it 'shows the button with correct sova link on a published child archival object' do
-      visit '/'
       visit "resources/#{@published_resource.id}/edit#tree::archival_object_#{@published_ao.id}"
 
       wait_for_ajax
@@ -112,7 +100,6 @@ describe 'View in SOVA toolbar button', js: true do
     end
 
     it 'does not show the button on an unpublished child archival object' do
-      visit '/'
       visit "resources/#{@published_resource.id}/edit#tree::archival_object_#{@unpublished_ao.id}"
 
       wait_for_ajax

--- a/frontend/views/shared/_component_toolbar.html.erb
+++ b/frontend/views/shared/_component_toolbar.html.erb
@@ -3,136 +3,122 @@
    suppressible = true if suppressible.nil?
    supports_events = true if supports_events.nil?
 %>
-<div class="row">
-  <div class="col-md-12">
-    <div class="record-toolbar">
-      <% if (suppressible && !record.suppressed) || !suppressible %>
-        <% if !['edit', 'update', 'create'].include?(controller.action_name) %>
-          <div class="btn-group pull-left">
-            <%= link_to I18n.t("actions.edit"), parent_link, :class => "btn btn-sm btn-primary" %>
-          </div>
-        <% end %>
-        <% if ['new', 'create', 'edit', 'update'].include?(controller.action_name) %>
-          <div class="pull-left save-changes">
-            <button type="submit" class="btn btn-primary btn-sm"><%= I18n.t("actions.save_prefix") %></button>
-          </div>
-        <% end %>
-        <% if ['edit', 'update'].include?(controller.action_name) %>
-          <div class="pull-left revert-changes">
-            <%= link_to I18n.t("actions.revert"), parent_link, :class => "btn btn-sm btn-default" %>
-            <%= I18n.t("actions.toolbar_disabled_message") %>
-          </div>
+<section class="d-flex flex-column">
+  <div class="d-flex align-items-center gap-x-2 record-toolbar" role="toolbar">
+    <% if (suppressible && !record.suppressed) || !suppressible %>
+      <% if !['edit', 'update', 'create'].include?(controller.action_name) %>
+        <div class="btn-group">
+          <%= link_to t("actions.edit"), parent_link, :class => "btn btn-sm btn-primary" %>
+        </div>
+      <% end %>
+      <% if ['new', 'create', 'edit', 'update'].include?(controller.action_name) %>
+        <div class="save-changes">
+          <button type="submit" class="btn btn-primary btn-sm"><%= t("actions.save_prefix") %></button>
+        </div>
+      <% end %>
+      <% if ['edit', 'update'].include?(controller.action_name) %>
+        <div class="align-items-center revert-changes">
+          <%= link_to t("actions.revert"), parent_link, :class => "btn btn-sm btn-default flex-shrink-0" %>
+        </div>
+      <% end %>
+    <% end %>
+
+    <div class="btn-group ml-auto" data-allow-disabled>
+      <% if user_can?('update_event_record') && supports_events && ((suppressible && !record.suppressed) || !suppressible ) %>
+        <%= render_aspace_partial :partial => "shared/event_dropdown", :locals => {:record => record} %>
+      <% end %>
+      <% if ['archival_object'].include?(record.jsonmodel_type) %>
+        <%= button_confirm_action(t("actions.publish_archival_object"),
+              url_for({:action => :publish, :id => record.id}),
+              {
+                :class => "btn btn-sm btn-default",
+                :"data-title" => t("actions.publish_archival_object_confirm_title"),
+                :"data-message" => t("actions.publish_archival_object_confirm_message"),
+                :"data-confirm-btn-label" => "#{t("actions.publish_archival_object")}",
+                :"data-confirm-btn-class" => "btn-primary",
+              }) %>
+        <%= button_confirm_action(t("actions.unpublish_archival_object"),
+              url_for({:action => :unpublish, :id => record.id}),
+              {
+                :class => "btn btn-sm btn-default",
+                :"data-title" => t("actions.unpublish_archival_object_confirm_title"),
+                :"data-message" => t("actions.unpublish_archival_object_confirm_message"),
+                :"data-confirm-btn-label" => "#{t("actions.unpublish_archival_object")}",
+                :"data-confirm-btn-class" => "btn-primary",
+              }) %>
+      <% end %>
+      <% if ['archival_object', 'digital_object_component'].include?(record.jsonmodel_type) %>
+        <% if AppConfig[:enable_public] && !record.has_unpublished_ancestor %>
+          <%= render_aspace_partial :partial => "shared/view_published_button", :locals => {:record => record} %>
         <% end %>
       <% end %>
-      <div class="btn-toolbar pull-right">
-        <div class="btn-group">
-          <% if user_can?('update_event_record') && supports_events && ((suppressible && !record.suppressed) || !suppressible ) %>
-            <%= render_aspace_partial :partial => "shared/event_dropdown", :locals => {:record => record} %>
-          <% end %>
-          <% if ['archival_object'].include?(record.jsonmodel_type) %>
-            <div class="btn-group">
-              <%= button_confirm_action(I18n.t("actions.publish_archival_object"),
-                        url_for({:action => :publish, :id => record.id}),
-                        {
-                          :class => "btn btn-sm btn-default",
-                          :"data-title" => I18n.t("actions.publish_archival_object_confirm_title"),
-                          :"data-message" => I18n.t("actions.publish_archival_object_confirm_message"),
-                          :"data-confirm-btn-label" => "#{I18n.t("actions.publish_archival_object")}",
-                          :"data-confirm-btn-class" => "btn-primary",
-                        }) %>
-            </div>
-            <div class="btn-group">
-              <%= button_confirm_action(I18n.t("actions.unpublish_archival_object"),
-                        url_for({:action => :unpublish, :id => record.id}),
-                        {
-                          :class => "btn btn-sm btn-default",
-                          :"data-title" => I18n.t("actions.unpublish_archival_object_confirm_title"),
-                          :"data-message" => I18n.t("actions.unpublish_archival_object_confirm_message"),
-                          :"data-confirm-btn-label" => "#{I18n.t("actions.unpublish_archival_object")}",
-                          :"data-confirm-btn-class" => "btn-primary",
-                        }) %>
-            </div>
-          <% end %>
-          <% if ['archival_object', 'digital_object_component'].include?(record.jsonmodel_type) %>
-            <% if AppConfig[:enable_public] && !record.has_unpublished_ancestor %>
-              <%= render_aspace_partial :partial => "shared/view_published_button", :locals => {:record => record} %>
+
+      <%# View in SOVA plugin start %>
+      <% if ['archival_object'].include?(record.jsonmodel_type) && JSONModel(:resource).find(parent_link[:id]).finding_aid_status == 'publish' && record.publish == true %>
+        <%= link_to t('view_in_sova'),
+                    URI::HTTPS.build(host: URI(AppConfig[:sova_url]).hostname,
+                                      path: ToolbarHelper::sova_link_from_record(record.ref_id, 'archival_object')).to_s,
+                    { :class => "btn btn-sm btn-default", :target => "_blank" } %>
+      <% end %>
+      <%# View in SOVA plugin end %>
+
+      <% if ['archival_object'].include?(record.jsonmodel_type) %>
+        <div class="btn-group dropdown" id="other-dropdown">
+          <button
+            class="btn btn-sm btn-default dropdown-toggle"
+            type="button"
+            data-toggle="dropdown"
+            aria-haspopup="true"
+            aria-expanded="true"
+          ><%= t('actions.more') %></button>
+          <ul class="dropdown-menu">
+            <li><%= render_aspace_partial :partial => "extent_calculator/toolbar_button", :locals => {:record => record} %></li>
+            <li><%= render_aspace_partial :partial => "date_calculator/toolbar_button", :locals => {:record => record} %></li>
+            <% if user_can?('update_assessment_record') %>
+              <li><%= link_to t('assessment._frontend.action.create_for_record'), {:controller => :assessments, :action => :new, :record_uri => record.uri}, :class => "dropdown-item" %></li>
             <% end %>
-          <% end %>
-
-          <%# View in SOVA plugin start %>
-          <% if ['archival_object'].include?(record.jsonmodel_type) && JSONModel(:resource).find(parent_link[:id]).finding_aid_status == 'publish' && record.publish == true %>
-            <%= link_to t('view_in_sova'),
-                        URI::HTTPS.build(host: URI(AppConfig[:sova_url]).hostname,
-                                         path: ToolbarHelper::sova_link_from_record(record.ref_id, 'archival_object')).to_s,
-                        { :class => "btn btn-sm btn-default", :target => "_blank" } %>
-          <% end %>
-          <%# View in SOVA plugin end %>
-
-          <div class="btn-group dropdown" id="other-dropdown" style="display: none">
-            <a class="btn btn-sm btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-              <%= I18n.t('actions.more') %>
-              <span class="caret"></span>
-            </a>
-
-            <% other_shown = false %>
-            <ul class="dropdown-menu">
-              <% if ['archival_object'].include?(record.jsonmodel_type) %>
-                <% other_shown = true %>
-                <li><%= render_aspace_partial :partial => "extent_calculator/toolbar_button", :locals => {:record => record} %></li>
-                <li><%= render_aspace_partial :partial => "date_calculator/toolbar_button", :locals => {:record => record} %></li>
-                <% if user_can?('update_assessment_record') %>
-                  <li><%= link_to I18n.t('assessment._frontend.action.create_for_record'), {:controller => :assessments, :action => :new, :record_uri => record.uri} %></li>
-                <% end %>
-
-                <% if user_can?('administer_system') && AppConfig[:arks_enabled] && record['ark_name'] %>
-                  <li><%= render_aspace_partial :partial => "shared/ark_editor", :locals => {:record => record} %>
-                <% end %>
-
-              <% end %>
-
-            <% if other_shown %><script>$('#other-dropdown').show();</script><% end %>
-          </div>
-
-          <% if user_can?('suppress_archival_record') || user_can?('delete_archival_record') %>
-            <div class="btn-group">
-              <div class="toolbar-spacer" />
-            </div>
-          <% end %>
-
-          <% if suppressible && user_can?('suppress_archival_record') %>
-            <div class="btn btn-inline-form">
-              <% if record.suppressed %>
-                <%= button_confirm_action I18n.t("actions.unsuppress"),
-                                          url_for(:action => :unsuppress, :id => record.id),
-                                          {
-                                            :class => "btn btn-sm unsuppress-record",
-                                            :"data-title" => I18n.t("actions.unsuppress_confirm_title"),
-                                            :"data-message" => I18n.t("actions.unsuppress_confirm_message"),
-                                            :"data-confirm-btn-label" => "#{I18n.t("actions.unsuppress")}"
-                                          }
-                %>
-              <% else %>
-                <%= button_confirm_action I18n.t("actions.suppress"),
-                                          url_for(:action => :suppress, :id => record.id),
-                                          {
-                                            :class => "btn btn-sm btn-warning suppress-record",
-                                            :"data-title" => I18n.t("actions.suppress_confirm_title"),
-                                            :"data-message" => I18n.t("actions.suppress_confirm_message"),
-                                            :"data-confirm-btn-label" => "#{I18n.t("actions.suppress")}",
-                                            :"data-confirm-btn-class" => "btn-warning"
-                                          }
-                %>
-              <% end %>
-            </div>
-          <% end %>
-          <% if user_can?('delete_archival_record') %>
-            <div class="btn btn-inline-form">
-              <%= button_delete_action url_for(:action => :delete, :id => record.id), { :"data-title" => I18n.t("actions.delete_confirm_title", :title => delete_action_title) } %>
-            </div>
-          <% end %>
+            <% if user_can?('administer_system') && AppConfig[:arks_enabled] && record['ark_name'] %>
+              <li><%= render_aspace_partial :partial => "shared/ark_editor", :locals => {:record => record} %>
+            <% end %>
+          </ul>
         </div>
-      </div>
-      <div class="clearfix"></div>
+      <% end %>
+
+      <% if suppressible && user_can?('suppress_archival_record') %>
+        <% if record.suppressed %>
+          <%= button_confirm_action t("actions.unsuppress"),
+                                    url_for(:action => :unsuppress, :id => record.id),
+                                    {
+                                      :class => "btn btn-sm btn-default unsuppress-record",
+                                      :"data-title" => t("actions.unsuppress_confirm_title"),
+                                      :"data-message" => t("actions.unsuppress_confirm_message"),
+                                      :"data-confirm-btn-label" => "#{t("actions.unsuppress")}"
+                                    }
+          %>
+        <% else %>
+          <%= button_confirm_action t("actions.suppress"),
+                                    url_for(:action => :suppress, :id => record.id),
+                                    {
+                                      :class => "btn btn-sm btn-warning suppress-record",
+                                      :"data-title" => t("actions.suppress_confirm_title"),
+                                      :"data-message" => t("actions.suppress_confirm_message"),
+                                      :"data-confirm-btn-label" => "#{t("actions.suppress")}",
+                                      :"data-confirm-btn-class" => "btn-warning"
+                                    }
+          %>
+        <% end %>
+      <% end %>
+      <% if user_can?('delete_archival_record') %>
+        <div class="btn btn-inline-form">
+          <%= button_delete_action url_for(:action => :delete, :id => record.id), { :"data-title" => t("actions.delete_confirm_title", :title => clean_mixed_content(delete_action_title)) } %>
+        </div>
+      <% end %>
     </div>
   </div>
-</div>
+
+  <% if ['edit', 'update'].include?(controller.action_name) %>
+    <div id="record-toolbar-alert">
+      <p class="mb-0 pt-1 pb-2 px-2 fs-12px"><%= t("actions.toolbar_disabled_message") %></p>
+    </div>
+  <% end %>
+</section>

--- a/frontend/views/shared/_resource_toolbar.html.erb
+++ b/frontend/views/shared/_resource_toolbar.html.erb
@@ -1,89 +1,102 @@
-<div class="record-toolbar">
-  <% if !record.suppressed %>
-    <% if !['edit', 'update', 'create'].include?(controller.action_name) %>
-      <div class="btn-group pull-left">
-        <%= link_to I18n.t("actions.edit"), {:action => :edit, :id => record.id, :anchor => "tree::#{record_type}_#{record.id}"}, :class => "btn btn-sm btn-primary" %>
+<section class="d-flex flex-column">
+  <div class="d-flex align-items-center gap-x-2 record-toolbar" role="toolbar">
+    <% if !record.suppressed %>
+      <% if !['edit', 'update', 'create'].include?(controller.action_name) %>
+        <div class="btn-group">
+          <%= link_to t("actions.edit"), {:action => :edit, :id => record.id, :anchor => "tree::#{record_type}_#{record.id}"}, :class => "btn btn-sm btn-primary" %>
+        </div>
+      <% end %>
+    <% end %>
+    <% if ['new', 'create', 'edit', 'update'].include?(controller.action_name) %>
+      <div class="save-changes">
+        <button type="submit" class="btn btn-primary btn-sm"><%= t("actions.save_prefix") %></button>
       </div>
     <% end %>
-  <% end %>
-  <% if ['new', 'create', 'edit', 'update'].include?(controller.action_name) %>
-    <div class="pull-left save-changes">
-      <button type="submit" class="btn btn-primary btn-sm"><%= I18n.t("actions.save_prefix") %></button>
-    </div>
-  <% end %>
-  <% if ['edit', 'update'].include?(controller.action_name) %>
-    <div class="pull-left revert-changes">
-      <%= link_to I18n.t("actions.revert"), {:action => :edit, :id => record.id}, :class => "btn btn-sm btn-default" %>
-      <%= I18n.t("actions.toolbar_disabled_message") %>
-    </div>
-  <% end %>
-  <div class="btn-toolbar pull-right">
-    <div class="btn-group">
+    <% if ['edit', 'update'].include?(controller.action_name) %>
+      <div class="align-items-center revert-changes">
+        <%= link_to t("actions.revert"), {:action => :edit, :id => record.id}, :class => "btn btn-sm btn-default flex-shrink-0" %>
+      </div>
+    <% end %>
+    <div class="btn-group ml-auto" data-allow-disabled>
       <% if user_can?('update_event_record') && !record.suppressed %>
         <%= render_aspace_partial :partial => "shared/event_dropdown", :locals => {:record => record} %>
       <% end %>
       <div class="btn-group">
-        <%= button_confirm_action(I18n.t("actions.publish"),
+        <%= button_confirm_action(t("actions.publish"),
                     url_for({:action => :publish, :id => record.id}),
                     {
                       :class => "btn btn-sm btn-default",
-                      :"data-title" => I18n.t("actions.publish_confirm_title"),
-                      :"data-message" => I18n.t("actions.publish_confirm_message"),
-                      :"data-confirm-btn-label" => "#{I18n.t("actions.publish")}",
+                      :"data-title" => t("actions.publish_confirm_title"),
+                      :"data-message" => t("actions.publish_confirm_message"),
+                      :"data-confirm-btn-label" => "#{t("actions.publish")}",
                       :"data-confirm-btn-class" => "btn-primary",
                     }) %>
       </div>
       <% if ['resource'].include?(record_type) %>
-        <div class="btn-group">
-          <%= button_confirm_action(I18n.t("actions.unpublish"),
-                                    url_for({:action => :unpublish, :id => record.id}),
-                                    {
-                                      :class => "btn btn-sm btn-default",
-                                      :"data-title" => I18n.t("actions.unpublish_confirm_title"),
-                                      :"data-message" => I18n.t("actions.unpublish_confirm_message"),
-                                      :"data-confirm-btn-label" => "#{I18n.t("actions.unpublish")}",
-                                      :"data-confirm-btn-class" => "btn-primary",
-                                    }) %>
-        </div>
+        <%= button_confirm_action(t("actions.unpublish"),
+                                  url_for({:action => :unpublish, :id => record.id}),
+                                  {
+                                    :class => "btn btn-sm btn-default",
+                                    :"data-title" => t("actions.unpublish_confirm_title"),
+                                    :"data-message" => t("actions.unpublish_confirm_message"),
+                                    :"data-confirm-btn-label" => "#{t("actions.unpublish")}",
+                                    :"data-confirm-btn-class" => "btn-primary",
+                                  }) %>
       <% end %>
       <% if AppConfig[:enable_public] %>
         <%= render_aspace_partial :partial => "shared/view_published_button", :locals => {:record => record} %>
       <% end %>
+
+      <% if @resource != nil %>
+        <div class="btn-group">
+          <%= link_to I18n.t("actions.duplicate_resource"), {
+              controller: :exports,
+              :action => :resource_duplicate,
+              :resource_id => @resource.id
+            },
+            :merge_destination => :_blank,
+            :class => "btn btn-sm btn-default",
+            :"data-confirmation" => true,
+            :"data-title" => I18n.t("actions.duplicate_resource", :title => @resource.title),
+            :"data-message" => I18n.t("actions.duplicate_resource_confirm_message"),
+            :"data-confirm-btn-label" => "#{I18n.t("actions.duplicate_resource")}",
+            :"data-authenticity_token" => form_authenticity_token,
+            :"data-confirm-btn-class" => "btn-warning"
+          %>
+        </div>
+      <% end %>
+
       <div class="btn-group">
-        <a class="btn btn-sm btn-default dropdown-toggle" data-toggle="dropdown" href="javascript:void(0);">
-          <%= I18n.t("actions.export") %>
-          <span class="caret"></span>
-        </a>
-        <ul class="dropdown-menu open-aligned-right">
+        <button
+          type="button"
+          id="export-dropdown-toggle"
+          class="btn btn-sm btn-default dropdown-toggle"
+          data-toggle="dropdown"
+        >
+          <%= t("actions.export") %>
+        </button>
+        <ul class="dropdown-menu dropdown-menu-right">
           <%= yield :exports %>
         </ul>
       </div>
-
-      <%# SNAC PLUGIN CONTENT SECTION STARTS HERE %>
-        <% if AppConfig[:plugins].include?('snac_aspace_plugin') %>
-          <%= render_aspace_partial :partial => "shared/snac_dropdown", :locals => {:obj => record} %>
-        <% end %>
-      <%# SNAC PLUGIN CONTENT SECTION ENDS HERE %>
-
       <% if user_can?('merge_archival_record') %>
         <%=
             render_aspace_partial :partial => "shared/merge_dropdown",
-                    :locals => {:record => record,
-                                :multiplicity => "one",
-                                :controller => controller.controller_name,
-                                :confirmation_title => I18n.t("actions.merge_confirm_title"),
-                                :confirmation_msg => I18n.t("actions.merge_resource_confirm_message",
-                                                            :source => record.title)}
+                  :locals => {:record => record,
+                              :multiplicity => "one",
+                              :controller => controller.controller_name,
+                              :confirmation_title => t("actions.merge_confirm_title"),
+                              :confirmation_msg => t("actions.merge_resource_confirm_message",
+                                                          :source => record.title)}
         %>
       <% end %>
       <% if user_can?('transfer_archival_record') %>
         <%=
-            render_aspace_partial :partial => "shared/transfer_dropdown",
+          render_aspace_partial :partial => "shared/transfer_dropdown",
                   :locals => {:record => record,
                               :controller => controller.controller_name,
-                              :confirmation_title => I18n.t("actions.transfer_confirm_title"),
-                              :confirmation_msg => I18n.t("actions.transfer_confirm_message",
-                                                          :target => record.title)}
+                              :confirmation_title => t("actions.transfer_confirm_title"),
+                              :confirmation_msg => t("actions.transfer_confirm_message", :target => record.title)}
         %>
       <% end %>
 
@@ -98,70 +111,77 @@
 
       <div class="btn-group dropdown" id="other-dropdown" style="display: none">
         <button class="btn btn-sm btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-          <%= I18n.t('actions.more') %>
-          <span class="caret"></span>
+          <%= t('actions.more') %>
         </button>
 
         <% other_shown = false %>
-        <ul class="dropdown-menu">
+        <ul class="dropdown-menu dropdown-menu-right">
           <% if ['resource', 'archival_object'].include?(record_type) %>
             <% other_shown = true %>
-            <li><%= render_aspace_partial :partial => "extent_calculator/toolbar_button", :locals => {:record => record} %></li>
-            <li><%= render_aspace_partial :partial => "date_calculator/toolbar_button", :locals => {:record => record} %></li>
+            <li><%= render_aspace_partial :partial => "extent_calculator/toolbar_button", :locals => {:record => record}, :class => "dropdown-item" %></li>
+            <li><%= render_aspace_partial :partial => "date_calculator/toolbar_button", :locals => {:record => record}, :class => "dropdown-item" %></li>
           <% end %>
           <% if ['resource', 'digital_object'].include?(record_type) %>
             <% if user_can?('update_assessment_record') %>
               <% other_shown = true %>
-              <li><%= link_to I18n.t('assessment._frontend.action.create_for_record'), {:controller => :assessments, :action => :new, :record_uri => record.uri} %></li>
+              <li><%= link_to t('assessment._frontend.action.create_for_record'), {:controller => :assessments, :action => :new, :record_uri => record.uri}, :class => "dropdown-item" %></li>
             <% end %>
           <% end %>
 
-          <% if user_can?('administer_system') && AppConfig[:arks_enabled] && record['ark_name'] %>
-            <li><%= render_aspace_partial :partial => "shared/ark_editor", :locals => {:record => record} %>
+          <% if @resource != nil %>
+            <li>
+              <%=
+                link_to t('bulk_archival_object_update_spreadsheet.title'),
+                {
+                  :controller => :bulk_archival_object_updater, :action => :download_form, :resource => @resource.uri
+                },
+                :class => "dropdown-item"
+              %>
+            </li>
           <% end %>
 
+          <% if user_can?('administer_system') && AppConfig[:arks_enabled] && record['ark_name'] %>
+            <li><%= render_aspace_partial :partial => "shared/ark_editor", :locals => {:record => record} %></li>
+          <% end %>
         </ul>
 
         <% if other_shown %><script>$('#other-dropdown').show();</script><% end %>
       </div>
 
-      <% if user_can?('suppress_archival_record') || user_can?('delete_archival_record') %>
-        <div class="btn-group">
-          <div class="toolbar-spacer" />
-        </div>
-
-      <% end %>
-
       <% if user_can?('suppress_archival_record') %>
-
         <% if record.suppressed %>
-          <%= button_confirm_action I18n.t("actions.unsuppress"),
+          <%= button_confirm_action t("actions.unsuppress"),
           url_for(:action => :unsuppress, :id => record.id),
             {
             :class => "btn btn-sm btn-default unsuppress-record",
-              :"data-title" => I18n.t("actions.unsuppress_confirm_title"),
-              :"data-message" => I18n.t("actions.unsuppress_confirm_message"),
-              :"data-confirm-btn-label" => "#{I18n.t("actions.unsuppress")}"
+              :"data-title" => t("actions.unsuppress_confirm_title"),
+              :"data-message" => t("actions.unsuppress_confirm_message"),
+              :"data-confirm-btn-label" => "#{t("actions.unsuppress")}"
               }
           %>
         <% else %>
-          <%= button_confirm_action I18n.t("actions.suppress"),
+          <%= button_confirm_action t("actions.suppress"),
           url_for(:action => :suppress, :id => record.id),
             {
             :class => "btn btn-sm btn-warning suppress-record",
-              :"data-title" => I18n.t("actions.suppress_confirm_title"),
-              :"data-message" => I18n.t("actions.suppress_confirm_message"),
-              :"data-confirm-btn-label" => "#{I18n.t("actions.suppress")}",
+              :"data-title" => t("actions.suppress_confirm_title"),
+              :"data-message" => t("actions.suppress_confirm_message"),
+              :"data-confirm-btn-label" => "#{t("actions.suppress")}",
               :"data-confirm-btn-class" => "btn-warning"
                 }
           %>
         <% end %>
-
       <% end %>
       <% if user_can?('delete_archival_record') %>
-        <%= button_delete_action url_for(:action => :delete, :id => record.id), { :"data-title" => I18n.t("actions.delete_confirm_title", :title => record.title) } %>
+        <%= button_delete_action url_for(:action => :delete, :id => record.id), { :"data-title" => t("actions.delete_confirm_title", :title => clean_mixed_content(record.title)) } %>
       <% end %>
     </div>
   </div>
-  <div class="clearfix"></div>
-</div>
+
+  <% if ['edit', 'update'].include?(controller.action_name) %>
+    <div id="record-toolbar-alert">
+      <p class="mb-0 pt-1 pb-2 px-2 fs-12px"><%= t("actions.toolbar_disabled_message") %></p>
+    </div>
+  <% end %>
+
+</section>


### PR DESCRIPTION
## Description
The toolbar views changed substantially between aspace v3.3.1 and v4.1.0 (as we expected based on prior runs of our diff checker), so we need to update our overrides to be compatible with v4.1.0.  This will ultimately become a v2.0.0 release of the plugin, and will be merged to main when we are ready to update production aspace to that version.

## Related GitHub Issue
Closes #19 

## Testing
Substantial test updates were also required to comply with frontend test changes in core `aspace_helper` and the like.

## Screenshot(s):
<img width="1102" alt="Screenshot 2025-05-30 at 2 43 17 PM" src="https://github.com/user-attachments/assets/bb2abe85-3eea-49b6-be10-ca2de9bd0a36" />


## Checklist

- [ ] ✔️ Have you assigned at least one reviewer?
Skipping, since this isn't a merge to main (yet)
- [x] 🔗 Have you referenced any issues this PR will close?
- [x] ⬇️ Have you merged the latest upstream changes into your branch? 
- [x] 🧪 Have you added tests to cover these changes?  If not, why:
- [x] 🤖 Have automated checks (if any) passed?  If not, please explain for the reviewer:
The diff checker is, understandably, failing against prior versions of aspace.
- [x] 📘 Have you updated/added any relevant readmes/comments in the codebase?
- [x] 📚 Have you updated/added any external documentation (e.g. Confluence)?
