### PR TITLE
21 whitespace

### DIFF
--- a/.github/workflows/frontend_plugin_test.yml
+++ b/.github/workflows/frontend_plugin_test.yml
@@ -16,7 +16,7 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        archivesspace_version: [v4.0.0, v4.1.0]
+        archivesspace_version: [v4.1.0, v4.1.1]
 
     services:
       db:

--- a/frontend/helpers/toolbar_helper.rb
+++ b/frontend/helpers/toolbar_helper.rb
@@ -1,6 +1,6 @@
 module ToolbarHelper
   def self.sova_link_from_record(record_id, record_type)
-    path = record_id.downcase
+    path = record_id.strip.downcase
     if record_type == 'archival_object'
       path.gsub!('_', '/')
     end

--- a/frontend/spec/features/toolbar_helper_spec.rb
+++ b/frontend/spec/features/toolbar_helper_spec.rb
@@ -6,11 +6,22 @@ require 'rails_helper.rb'
 describe ToolbarHelper do
   describe '#sova_link_from_record' do
     context 'when a resource' do
-      let(:record_id) {'EAD.123'}
       let(:record_type) { 'resource' }
 
-      it "returns '/record/{downcased-eadid}'" do
-        expect(ToolbarHelper::sova_link_from_record(record_id, record_type)).to eq('/record/ead.123')
+      context 'when a standard ead_id' do
+        let(:record_id) {'EAD.123'}
+      
+        it "returns '/record/{downcased-eadid}'" do
+          expect(ToolbarHelper::sova_link_from_record(record_id, record_type)).to eq('/record/ead.123')
+        end
+      end
+
+      context 'when ead_id has trailing whitespace' do
+        let(:record_id) {'EAD.123 '}
+      
+        it 'strips the trailing whitespace' do
+          expect(ToolbarHelper::sova_link_from_record(record_id, record_type)).to eq('/record/ead.123')
+        end
       end
     end
 

--- a/frontend/spec/features/toolbar_spec.rb
+++ b/frontend/spec/features/toolbar_spec.rb
@@ -27,7 +27,7 @@ def add_enum
     run_index_round
 
     visit "resources/#{@published_resource.id}/edit"
-    select 'publish', from: 'Finding Aid Status'
+    find("#resource_finding_aid_status_ option[value='publish']").select_option
     within '#archivesSpaceSidebar' do
       click_on 'Save Resource'
     end


### PR DESCRIPTION
## Description
<!--- Describe your changes.  Why is this required?  What problem does it solve?  What functionality does it extend? -->
Strips leading and trailing whitespace from ead_ids so that the SOVA button doesn't lead to a server error.

Also updates the versions of aspace we'd like to use in CI post-v4.1.0 upgrade, and adjusts a test so that it plays nicely if we've got our local plugin enabled.

Note: This is really just the tip of the iceberg of potential button/ref_id issues, but this makes things incrementally better.  We may still end up with broken links from bad EAD_IDs that contain internal (not leading or trailing) whitespace, but those will also generate ref_id plugin errors since ref_ids with whitespace will fail validation at the archival object level.  A real holistic approach to solving this will be addressed in https://github.com/Smithsonian/caas-aspace-deployment/issues/85, but this makes things marginally better in the short term until we can more specifically address the issues that arise from keying important functions off of a free-text field where just about anything is possible like EAD ID.

## Related GitHub Issue
Closes #21 

## Testing
New test added.

## Screenshot(s):
<!--- Optional screenshots of changes if relevant and helpful to reviewers -->

## Checklist

- [x] ✔️ Have you assigned at least one reviewer?
- [x] 🔗 Have you referenced any issues this PR will close?
- [x] ⬇️ Have you merged the latest upstream changes into your branch? 
- [x] 🧪 Have you added tests to cover these changes?  If not, why:
- [x] 🤖 Have automated checks (if any) passed?  If not, please explain for the reviewer:
- [x] 📘 Have you updated/added any relevant readmes/comments in the codebase?
- [x] 📚 Have you updated/added any external documentation (e.g. Confluence)?
